### PR TITLE
解决在其他页面触发了setState操作

### DIFF
--- a/lib/components/core/EditorContentEditableDiv.react.js
+++ b/lib/components/core/EditorContentEditableDiv.react.js
@@ -31,6 +31,8 @@ var EditorContentEditableDiv = function (_React$Component) {
 	_createClass(EditorContentEditableDiv, [{
 		key: 'componentDidMount',
 		value: function componentDidMount(e) {
+			this.handleWindowMouseDown = this.handleWindowMouseDown.bind(this)
+			this.handleMouseUp = this.handleMouseUp.bind(this)
 			window.addEventListener("mousedown", this.handleWindowMouseDown.bind(this));
 			window.addEventListener("mouseup", this.handleMouseUp.bind(this));
 		}

--- a/lib/components/core/EditorContentEditableDiv.react.js
+++ b/lib/components/core/EditorContentEditableDiv.react.js
@@ -33,14 +33,14 @@ var EditorContentEditableDiv = function (_React$Component) {
 		value: function componentDidMount(e) {
 			this.handleWindowMouseDown = this.handleWindowMouseDown.bind(this);
 			this.handleMouseUp = this.handleMouseUp.bind(this);
-			window.addEventListener("mousedown", this.handleWindowMouseDown.bind(this));
-			window.addEventListener("mouseup", this.handleMouseUp.bind(this));
+			window.addEventListener("mousedown", this.handleWindowMouseDown);
+			window.addEventListener("mouseup", this.handleMouseUp);
 		}
 	}, {
 		key: 'componentWillUnmount',
 		value: function componentWillUnmount(e) {
-			window.removeEventListener("mousedown", this.handleWindowMouseDown.bind(this));
-			window.removeEventListener("mouseup", this.handleMouseUp.bind(this));
+			window.removeEventListener("mousedown", this.handleWindowMouseDown);
+			window.removeEventListener("mouseup", this.handleMouseUp);
 		}
 	}, {
 		key: 'componentWillUpdate',

--- a/lib/components/core/EditorContentEditableDiv.react.js
+++ b/lib/components/core/EditorContentEditableDiv.react.js
@@ -31,8 +31,8 @@ var EditorContentEditableDiv = function (_React$Component) {
 	_createClass(EditorContentEditableDiv, [{
 		key: 'componentDidMount',
 		value: function componentDidMount(e) {
-			this.handleWindowMouseDown = this.handleWindowMouseDown.bind(this)
-			this.handleMouseUp = this.handleMouseUp.bind(this)
+			this.handleWindowMouseDown = this.handleWindowMouseDown.bind(this);
+			this.handleMouseUp = this.handleMouseUp.bind(this);
 			window.addEventListener("mousedown", this.handleWindowMouseDown.bind(this));
 			window.addEventListener("mouseup", this.handleMouseUp.bind(this));
 		}

--- a/src/components/core/EditorContentEditableDiv.react.js
+++ b/src/components/core/EditorContentEditableDiv.react.js
@@ -14,12 +14,12 @@ class EditorContentEditableDiv extends React.Component{
 	componentDidMount(e){
 		this.handleWindowMouseDown = this.handleWindowMouseDown.bind(this)
 		this.handleMouseUp = this.handleMouseUp.bind(this)
-		window.addEventListener("mousedown",this.handleWindowMouseDown.bind(this));
-		window.addEventListener("mouseup",this.handleMouseUp.bind(this));
+		window.addEventListener("mousedown",this.handleWindowMouseDown);
+		window.addEventListener("mouseup",this.handleMouseUp);
 	}
 	componentWillUnmount(e){
-		window.removeEventListener("mousedown",this.handleWindowMouseDown.bind(this));
-		window.removeEventListener("mouseup",this.handleMouseUp.bind(this));
+		window.removeEventListener("mousedown",this.handleWindowMouseDown);
+		window.removeEventListener("mouseup",this.handleMouseUp);
 	}
 	componentWillUpdate(e){
 		// EditorSelection.cloneRange();

--- a/src/components/core/EditorContentEditableDiv.react.js
+++ b/src/components/core/EditorContentEditableDiv.react.js
@@ -12,6 +12,8 @@ class EditorContentEditableDiv extends React.Component{
 		}
 	}
 	componentDidMount(e){
+		this.handleWindowMouseDown = this.handleWindowMouseDown.bind(this)
+		this.handleMouseUp = this.handleMouseUp.bind(this)
 		window.addEventListener("mousedown",this.handleWindowMouseDown.bind(this));
 		window.addEventListener("mouseup",this.handleMouseUp.bind(this));
 	}
@@ -30,7 +32,7 @@ class EditorContentEditableDiv extends React.Component{
 		// loaded状态变化时，务必重新刷新
 		var currentValue = nextProps.value;
 		var editorValue = this.getContent();
-		
+
 		if(currentValue == editorValue){
 			return false;
 		}
@@ -40,7 +42,7 @@ class EditorContentEditableDiv extends React.Component{
 		var target = ReactDOM.findDOMNode(this.refs.edit);
 		return target.innerHTML;
 	}
-	setContent(content){ 
+	setContent(content){
 		if(this.getContent() == content) return;
 		this.setState({
 			content:content
@@ -67,7 +69,7 @@ class EditorContentEditableDiv extends React.Component{
 	}
 	handleMouseUp(e){
 		EditorSelection.createRange();
-		if(this.props.onRangeChange) 
+		if(this.props.onRangeChange)
 			this.props.onRangeChange(e);
 		EditorDOM.stopPropagation(e);
 	}


### PR DESCRIPTION
window.addEventListener("mousedown", this.handleWindowMouseDown.bind(this))
window.removeEventListener("mousedown",this.handleWindowMouseDown.bind(this))
因为bind会创建一个新函数，所以add的是一个新函数，remove的是一个新函数。它俩并不是一个函数。
继而没有remove掉add的event。
现在换成
window.addEventListener("mousedown", this.handleWindowMouseDown)
window.removeEventListener("mousedown", this.handleWindowMouseDown)
add和remove的同一个函数。
但是在add的时候需要将this传过去，所以需要加上
this.handleWindowMouseDown = this.handleWindowMouseDown.bind(this)