### PR TITLE
修复输入内容后插入图片，表格等内容位置错误的问题

### DIFF
--- a/src/components/core/EditorContentEditableDiv.react.js
+++ b/src/components/core/EditorContentEditableDiv.react.js
@@ -104,11 +104,19 @@ class EditorContentEditableDiv extends React.Component{
 			<div className="editor-contenteditable-div">
 				<EditorResize ref="resize" />
 				<div className="editable-range"
-          		ref="edit"
-				onMouseUp={this.handleMouseUp}
-          		onMouseDown={this.handleMouseDown}
-				contentEditable={true}
-          		dangerouslySetInnerHTML={{__html:this.state.content}}/>
+					ref="edit"
+					onMouseUp={this.handleMouseUp}
+					onMouseDown={this.handleMouseDown}
+					onInput={(e)=>{
+						EditorSelection.selection = EditorSelection.getSelection();
+						if(EditorSelection.selection && EditorSelection.selection.rangeCount>0) {
+							EditorSelection.range = EditorSelection.selection.getRangeAt(0).cloneRange();
+						}else{
+							EditorSelection.range = null;
+						}
+					}}
+					contentEditable={true}
+					dangerouslySetInnerHTML={{__html:this.state.content}}/>
 			</div>)
 	}
 }


### PR DESCRIPTION
输入一段内容，点击插入表格，光标移动到了输入之前的地方来插入了表格